### PR TITLE
fix(status): load keyword index and show actual watch mode status

### DIFF
--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -94,7 +94,30 @@ export function registerStatusCommand(program: Command): void {
         logCliInfo(logFilePath, "status", `${c.label("Pending files:")}     ${c.num(summary.pendingFiles)}`);
         logCliInfo(logFilePath, "status", `${c.label("Indexed chunks:")}    ${c.num(summary.storeChunkCount)}`);
         logCliInfo(logFilePath, "status", `${c.label("Expected chunks:")}   ${c.num(summary.manifestExpectedChunks)}`);
-        logCliInfo(logFilePath, "status", `${c.label("Watch mode:")}        ${c.dim("off")}`);
+        // Read watcher status from the background auto-indexer
+        const watcherStatusPath = path.join(storePath, "watcher-status.json");
+        let watchModeDisplay: string;
+        if (fs.existsSync(watcherStatusPath)) {
+          try {
+            const raw = fs.readFileSync(watcherStatusPath, "utf-8");
+            const ws = JSON.parse(raw) as { running?: boolean; lastRunAt?: number };
+            if (ws.lastRunAt) {
+              const lastRun = formatTimestamp(ws.lastRunAt);
+              watchModeDisplay = ws.running
+                ? c.enabled("active") + c.dim(" (last run: " + lastRun + ")")
+                : c.enabled("on") + c.dim(" (last run: " + lastRun + ")");
+            } else {
+              watchModeDisplay = c.enabled("on");
+            }
+          } catch {
+            watchModeDisplay = c.enabled("on") + c.dim(" (status unknown)");
+          }
+        } else if (config.openCode.autoIndex?.enabled) {
+          watchModeDisplay = c.enabled("enabled (config)");
+        } else {
+          watchModeDisplay = c.dim("off");
+        }
+        logCliInfo(logFilePath, "status", `${c.label("Watch mode:")}        ${watchModeDisplay}`);
         const kiCount = config.retrieval.hybridSearch?.enabled
           ? keywordIndex?.count() ?? 0
           : 0;

--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -64,7 +64,7 @@ export function registerStatusCommand(program: Command): void {
       try {
         const cwd = process.cwd();
         let logFilePath = path.resolve(cwd, ".opencode", "opencode-rag.log");
-        const ctx = await resolveCliContext(options, logFilePath, { skipProbe: true, skipKeywordIndex: true });
+        const ctx = await resolveCliContext(options, logFilePath, { skipProbe: true });
         const { config, store, storePath, keywordIndex } = ctx;
         logFilePath = ctx.logFilePath;
 


### PR DESCRIPTION
## Summary

Two small fixes to `opencode-rag status` that correct misleading display values:

### 1. Keyword index count always showed 0

**Root cause:** The status command passed `skipKeywordIndex: true` to `resolveCliContext`, which created an empty `KeywordIndex` stub instead of loading the real one from disk. The `count()` always returned 0 regardless of actual index size.

**Fix:** Remove `skipKeywordIndex: true` so the real keyword index is loaded and `count()` returns the actual chunk count.

**Before:** `Keyword index: enabled (0 chunks)`  
**After:** `Keyword index: enabled (5538 chunks)`

### 2. Watch mode always showed "off"

**Root cause:** The status command hardcoded `Watch mode: off` with `c.dim("off")`. It never checked whether the background auto-indexer (`createBackgroundIndexer`) was active.

**Fix:** Read `watcher-status.json` from the vector store directory — written by `createBackgroundIndexer()` after every index pass. The display now shows:
- `active (last run: ...)` — watcher currently running a pass
- `on (last run: ...)` — watcher has been active recently
- `enabled (config)` — auto-index configured but no watcher file yet
- `off` — no watcher configured or running

**Before:** `Watch mode: off`  
**After:** `Watch mode: on (last run: 29/06/2026, 23:16:20)`

### Changes

| File | Change |
|------|--------|
| `src/cli/commands/status.ts` | Removed `skipKeywordIndex: true` + added watcher-status.json reader |

Both changes are TypeScript only — rebuild with `npm run build` to compile.
